### PR TITLE
Fix for automatic refresh not working

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -88,7 +88,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Controllers
         /// <summary>
         /// This action redraw the dashboard with the new cached datas, it's only called from the SignalR event
         /// </summary>
-        [Ajax]
+        //[Ajax]
         [Route("update-dashboard")]
         public IActionResult UpdateDashboard()
         {

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -88,7 +88,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Controllers
         /// <summary>
         /// This action redraw the dashboard with the new cached datas, it's only called from the SignalR event
         /// </summary>
-        //[Ajax]
+        [Ajax]
         [Route("update-dashboard")]
         public IActionResult UpdateDashboard()
         {

--- a/HostedServices/FetchingBackgroundService.cs
+++ b/HostedServices/FetchingBackgroundService.cs
@@ -72,8 +72,9 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
 
             DoWorkAsync(null);
 
-            //TODO: Add timer setting in configuration file
-            this.dataRetrieverTimer = new Timer(DoWorkAsync, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+            int interval = Int32.Parse(this.defaultEndpointsSettings.IntervalTime);
+
+            this.dataRetrieverTimer = new Timer(DoWorkAsync, null, TimeSpan.Zero, TimeSpan.FromSeconds(interval));
             await Task.CompletedTask;
         }
 
@@ -160,7 +161,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
                 sidechainNode.BlockHeight = (int) nodeDataServiceSidechain.NodeStatus.BlockStoreHeight;
                 sidechainNode.MempoolSize = nodeDataServiceSidechain.RawMempool;
 
-                sidechainNode.CoinTicker = "TCRS";
+                sidechainNode.CoinTicker = "CRS";
                 sidechainNode.LogRules = nodeDataServiceSidechain.LogRules;
                 sidechainNode.PoAPendingPolls = nodeDataServiceSidechain.PendingPolls;
                 sidechainNode.Uptime = nodeDataServiceSidechain.NodeStatus.Uptime;

--- a/HostedServices/FetchingBackgroundService.cs
+++ b/HostedServices/FetchingBackgroundService.cs
@@ -123,8 +123,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
                 var stratisNode = new StratisNodeModel();
 
                 stratisNode.History = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).WalletHistory : new JArray();
-                stratisNode.ConfirmedBalance = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).WalletBalance.confirmedBalance : -1;
-                stratisNode.UnconfirmedBalance = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).WalletBalance.unconfirmedBalance : -1;
+                stratisNode.ConfirmedBalance = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).FedWalletBalance.confirmedBalance : -1;
+                stratisNode.UnconfirmedBalance = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).FedWalletBalance.unconfirmedBalance : -1;
                 
                 stratisNode.WebAPIUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.StratisNode, "/api").ToString();
                 stratisNode.SwaggerUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.StratisNode, "/swagger").ToString();
@@ -149,8 +149,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
                 var sidechainNode = new SidechainNodeModel();
 
                 sidechainNode.History = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).WalletHistory : new JArray();
-                sidechainNode.ConfirmedBalance = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).WalletBalance.confirmedBalance : -1;
-                sidechainNode.UnconfirmedBalance = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).WalletBalance.unconfirmedBalance : -1;
+                sidechainNode.ConfirmedBalance = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).FedWalletBalance.confirmedBalance : -1;
+                sidechainNode.UnconfirmedBalance = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).FedWalletBalance.unconfirmedBalance : -1;
 
                 sidechainNode.WebAPIUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.SidechainNode, "/api").ToString();
                 sidechainNode.SwaggerUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.SidechainNode, "/swagger").ToString();

--- a/HostedServices/FetchingBackgroundService.cs
+++ b/HostedServices/FetchingBackgroundService.cs
@@ -174,8 +174,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
                 sidechainNode.BlockProducerHits =
                     this.nodeDataServiceSidechain.NodeDashboardStats?.BlockProducerHits ?? string.Empty;
                 sidechainNode.BlockProducerHitsValue = this.nodeDataServiceSidechain.NodeDashboardStats?.BlockProducerHitsValue ?? 0;
-                sidechainNode.WalletBalance = this.nodeDataServiceSidechain.WalletBalance;
-
+                sidechainNode.ConfirmedBalance = this.nodeDataServiceSidechain.WalletBalance.confirmedBalance;
+                sidechainNode.UnconfirmedBalance = this.nodeDataServiceSidechain.WalletBalance.unconfirmedBalance;
                 dashboardModel.SidechainNode = sidechainNode;
             }
             catch(Exception e)

--- a/HostedServices/FetchingBackgroundService.cs
+++ b/HostedServices/FetchingBackgroundService.cs
@@ -123,8 +123,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
                 var stratisNode = new StratisNodeModel();
 
                 stratisNode.History = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).WalletHistory : new JArray();
-                stratisNode.ConfirmedBalance = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).FedWalletBalance.confirmedBalance : -1;
-                stratisNode.UnconfirmedBalance = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).FedWalletBalance.unconfirmedBalance : -1;
+                stratisNode.ConfirmedBalanceFed = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).FedWalletBalance.confirmedBalance : -1;
+                stratisNode.UnconfirmedBalanceFed = this.is50K ? ((NodeGetDataServiceMultisig)nodeDataServiceMainchain).FedWalletBalance.unconfirmedBalance : -1;
                 
                 stratisNode.WebAPIUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.StratisNode, "/api").ToString();
                 stratisNode.SwaggerUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.StratisNode, "/swagger").ToString();
@@ -149,8 +149,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
                 var sidechainNode = new SidechainNodeModel();
 
                 sidechainNode.History = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).WalletHistory : new JArray();
-                sidechainNode.ConfirmedBalance = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).FedWalletBalance.confirmedBalance : -1;
-                sidechainNode.UnconfirmedBalance = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).FedWalletBalance.unconfirmedBalance : -1;
+                sidechainNode.ConfirmedBalanceFed = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).FedWalletBalance.confirmedBalance : -1;
+                sidechainNode.UnconfirmedBalanceFed = this.is50K ? ((NodeDataServiceSidechainMultisig)nodeDataServiceSidechain).FedWalletBalance.unconfirmedBalance : -1;
 
                 sidechainNode.WebAPIUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.SidechainNode, "/api").ToString();
                 sidechainNode.SwaggerUrl = UriHelper.BuildUri(this.defaultEndpointsSettings.SidechainNode, "/swagger").ToString();
@@ -174,6 +174,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.HostedServices
                 sidechainNode.BlockProducerHits =
                     this.nodeDataServiceSidechain.NodeDashboardStats?.BlockProducerHits ?? string.Empty;
                 sidechainNode.BlockProducerHitsValue = this.nodeDataServiceSidechain.NodeDashboardStats?.BlockProducerHitsValue ?? 0;
+                sidechainNode.WalletBalance = this.nodeDataServiceSidechain.WalletBalance;
 
                 dashboardModel.SidechainNode = sidechainNode;
             }

--- a/Models/StratisNodeModel.cs
+++ b/Models/StratisNodeModel.cs
@@ -16,7 +16,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Models
         public string BlockHash { get; set; }
         public double ConfirmedBalanceFed { get; set; }
         public double UnconfirmedBalanceFed { get; set; }
-        public (double confirmedBalance, double unconfirmedBalance) WalletBalance { get; set; } = (0, 0);
+        public double ConfirmedBalance { get; set; }
+        public double UnconfirmedBalance { get; set; }
         public List<Peer> Peers { get; set; }
         public List<Peer> FederationMembers { get; set; }
         public object History { get; set; }

--- a/Models/StratisNodeModel.cs
+++ b/Models/StratisNodeModel.cs
@@ -14,8 +14,9 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Models
         public int BlockHeight { get; set; }
         public int MempoolSize { get; set; }
         public string BlockHash { get; set; }
-        public double ConfirmedBalance { get; set; }
-        public double UnconfirmedBalance { get; set; }
+        public double ConfirmedBalanceFed { get; set; }
+        public double UnconfirmedBalanceFed { get; set; }
+        public (double confirmedBalance, double unconfirmedBalance) WalletBalance { get; set; } = (0, 0);
         public List<Peer> Peers { get; set; }
         public List<Peer> FederationMembers { get; set; }
         public object History { get; set; }

--- a/Services/NodeGetDataService.cs
+++ b/Services/NodeGetDataService.cs
@@ -178,8 +178,13 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
             try
             {
                 ApiResponse responseFiles = await _apiRequester.GetRequestAsync(_endpoint, "/api/Wallet/files");
-                string firstWalletName = responseFiles.Content.walletsFiles[0].Split;
-                //walletName = firstWalletName.
+
+                string firstWalletName = responseFiles.Content.walletsFiles[0].ToString().Split(".")[0];
+
+                ApiResponse responseBalance = await _apiRequester.GetRequestAsync(_endpoint, "/api/Wallet/balance", $"WalletName={firstWalletName}");
+
+                confirmed = responseBalance.Content.balances[0].amountConfirmed / STRATOSHI;
+                unconfirmed = responseBalance.Content.balances[0].amountUnconfirmed / STRATOSHI;
             }
             catch (Exception ex)
             {

--- a/Services/NodeGetDataService.cs
+++ b/Services/NodeGetDataService.cs
@@ -28,6 +28,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
         public ApiResponse FedInfoResponse { get; set; }
         public List<PendingPoll> PendingPolls { get; set; }
         public int FedMemberCount { get; set; }
+        public (double confirmedBalance, double unconfirmedBalance) WalletBalance { get; set; } = (0, 0);
         public NodeDashboardStats NodeDashboardStats { get; set; }
         public string MiningPubKey { get; set; }
 
@@ -151,7 +152,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
             return hash;
         }
 
-        protected async Task<(double, double)> UpdateWalletBalancec()
+        protected async Task<(double, double)> UpdateWalletBalance()
         {
             double confirmed = 0;
             double unconfirmed = 0;
@@ -166,6 +167,24 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
                 this.logger.LogError(ex, "Failed to get wallet balance");
             }
 
+            return (confirmed, unconfirmed);
+        }
+
+        protected async Task<(double, double)> UpdateMiningWalletBalance()
+        {
+            double confirmed = 0;
+            double unconfirmed = 0;
+            string walletName = String.Empty;
+            try
+            {
+                ApiResponse responseFiles = await _apiRequester.GetRequestAsync(_endpoint, "/api/Wallet/files");
+                string firstWalletName = responseFiles.Content.walletsFiles[0].Split;
+                //walletName = firstWalletName.
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Failed to get mining wallet balance");
+            }
             return (confirmed, unconfirmed);
         }
 
@@ -325,7 +344,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
 
     public class NodeGetDataServiceMultisig : NodeGetDataService
     {
-        public (double confirmedBalance, double unconfirmedBalance) WalletBalance { get; set; } = (0, 0);
+        public (double confirmedBalance, double unconfirmedBalance) FedWalletBalance { get; set; } = (0, 0);
         public object WalletHistory { get; set; }
         public string FedAddress { get; set; }
 
@@ -342,7 +361,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
             LogRules = await this.UpdateLogRules();
             RawMempool = await this.UpdateMempool();
             BestHash = await this.UpdateBestHash();
-            WalletBalance = await this.UpdateWalletBalancec();
+            FedWalletBalance = await this.UpdateWalletBalance();
             WalletHistory = await this.UpdateHistory();
             FedAddress = await this.UpdateFedInfo();
             return this;
@@ -363,7 +382,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
             LogRules = await UpdateLogRules();
             RawMempool = await UpdateMempool();
             BestHash = await UpdateBestHash();
-            WalletBalance = await UpdateWalletBalancec();
+            FedWalletBalance = await UpdateWalletBalance();
+            WalletBalance = await UpdateMiningWalletBalance();
             WalletHistory = await UpdateHistory();
             FedAddress = await UpdateFedInfo();
             PendingPolls = await UpdatePolls();
@@ -386,6 +406,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
             LogRules = await UpdateLogRules();
             RawMempool = await UpdateMempool();
             BestHash = await UpdateBestHash();
+            WalletBalance = await UpdateMiningWalletBalance();
             PendingPolls = await UpdatePolls();
             FedMemberCount = await UpdateFedMemberCount();
             return this;

--- a/Services/NodeGetDataService.cs
+++ b/Services/NodeGetDataService.cs
@@ -89,8 +89,10 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
                 StatusResponse = await _apiRequester.GetRequestAsync(_endpoint, "/api/Node/status");
                 nodeStatus.BlockStoreHeight = StatusResponse.Content.blockStoreHeight;
                 nodeStatus.ConsensusHeight = StatusResponse.Content.consensusHeight;
-                string upTimeLargePrecion = StatusResponse.Content.runningTime;
-                nodeStatus.Uptime = upTimeLargePrecion.Split('.')[0];
+                string runningTime = StatusResponse.Content.runningTime;
+                string[] parseTime = runningTime.Split('.');
+                parseTime = parseTime.Take(parseTime.Length - 1).ToArray();
+                nodeStatus.Uptime = string.Join(".",parseTime);
                 nodeStatus.State = StatusResponse.Content.state;
             }
             catch (Exception ex)

--- a/Services/NodeGetDataService.cs
+++ b/Services/NodeGetDataService.cs
@@ -159,15 +159,14 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
             try
             {
                 ApiResponse response = await _apiRequester.GetRequestAsync(_endpoint, "/api/FederationWallet/balance");
-                confirmed = response.Content.balances[0].amountConfirmed / STRATOSHI;
-                unconfirmed = response.Content.balances[0].amountUnconfirmed / STRATOSHI;
+                Double.TryParse(response.Content.balances[0].amountConfirmed.ToString(), out confirmed);
+                Double.TryParse(response.Content.balances[0].amountUnconfirmed.ToString(), out unconfirmed);
             }
             catch (Exception ex)
             {
                 this.logger.LogError(ex, "Failed to get wallet balance");
             }
-
-            return (confirmed, unconfirmed);
+            return (confirmed / STRATOSHI, unconfirmed / STRATOSHI);
         }
 
         protected async Task<(double, double)> UpdateMiningWalletBalance()
@@ -183,19 +182,20 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Services
 
                 ApiResponse responseBalance = await _apiRequester.GetRequestAsync(_endpoint, "/api/Wallet/balance", $"WalletName={firstWalletName}");
 
-                confirmed = responseBalance.Content.balances[0].amountConfirmed / STRATOSHI;
-                unconfirmed = responseBalance.Content.balances[0].amountUnconfirmed / STRATOSHI;
+                Double.TryParse(responseBalance.Content.balances[0].amountConfirmed.ToString(), out confirmed);
+                Double.TryParse(responseBalance.Content.balances[0].amountUnconfirmed.ToString(), out unconfirmed);
             }
             catch (Exception ex)
             {
                 this.logger.LogError(ex, "Failed to get mining wallet balance");
             }
-            return (confirmed, unconfirmed);
+            return (confirmed / STRATOSHI, unconfirmed / STRATOSHI);
         }
 
         protected async Task<Object> UpdateHistory()
         {
             object history = new Object();
+
             try
             {
                 ApiResponse response = await _apiRequester.GetRequestAsync(_endpoint, "/api/FederationWallet/history", "maxEntriesToReturn=30");

--- a/Settings/DefaultEndpointsSettings.cs
+++ b/Settings/DefaultEndpointsSettings.cs
@@ -6,6 +6,7 @@ namespace Stratis.FederatedSidechains.AdminDashboard.Settings
         public string SidechainNode { get; set; }
         public string SidechainNodeType { get; set; }
         public string EnvType { get; set; }
+        public string IntervalTime { get; set; } 
 
         public override string ToString()
         {

--- a/Startup.cs
+++ b/Startup.cs
@@ -29,7 +29,8 @@ namespace Stratis.FederatedSidechains.AdminDashboard
                 StratisNode = !string.IsNullOrEmpty(this.Configuration["mainchainport"]) ? $"http://localhost:{this.Configuration["mainchainport"]}" : defaultEndpoints["StratisNode"],
                 EnvType = defaultEndpoints["EnvType"],
                 SidechainNodeType = this.Configuration["nodetype"] ?? defaultEndpoints["SidechainNodeType"],
-                SidechainNode = !string.IsNullOrEmpty(this.Configuration["sidechainport"]) ? $"http://localhost:{this.Configuration["sidechainport"]}" : defaultEndpoints["SidechainNode"]
+                SidechainNode = !string.IsNullOrEmpty(this.Configuration["sidechainport"]) ? $"http://localhost:{this.Configuration["sidechainport"]}" : defaultEndpoints["SidechainNode"],
+                IntervalTime = defaultEndpoints["IntervalTime"]
             };
 
             if (!string.IsNullOrEmpty(this.Configuration["nodetype"]))

--- a/Views/Shared/Dashboard.cshtml
+++ b/Views/Shared/Dashboard.cshtml
@@ -307,6 +307,14 @@
                             </li>
                         </ul>
                     </li>
+                    <li class="col-12">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Mining Wallet balance :</strong></li>
+                            <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.ConfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                            <li class="list-inline-item text-muted">/</li>
+                            <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.UnconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                        </ul>
+                    </li>
                     @if (fiftyKOnlyFeature)
                     {
                         <li class="col-12">

--- a/Views/Shared/Dashboard.cshtml
+++ b/Views/Shared/Dashboard.cshtml
@@ -116,9 +116,9 @@
                         <li class="col-12 col-xl-12">
                             <ul class="list-inline">
                                 <li class="list-inline-item"><strong>Federation Wallet balance :</strong></li>
-                                <li class="list-inline-item text-green">Confirmed: @Model.StratisNode.ConfirmedBalance.ToString("N8") @Model.StratisNode.CoinTicker</li>
+                                <li class="list-inline-item text-green">Confirmed: @Model.StratisNode.ConfirmedBalanceFed.ToString("N8") @Model.StratisNode.CoinTicker</li>
                                 <li class="list-inline-item text-muted">/</li>
-                                <li class="list-inline-item text-muted">Unconfirmed: @Model.StratisNode.UnconfirmedBalance.ToString("N8") @Model.StratisNode.CoinTicker</li>
+                                <li class="list-inline-item text-muted">Unconfirmed: @Model.StratisNode.UnconfirmedBalanceFed.ToString("N8") @Model.StratisNode.CoinTicker</li>
                             </ul>
                         </li>
                     }
@@ -310,9 +310,9 @@
                     <li class="col-12">
                         <ul class="list-inline">
                             <li class="list-inline-item"><strong>Mining Wallet balance :</strong></li>
-                            <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.ConfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                            <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.WalletBalance.confirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
                             <li class="list-inline-item text-muted">/</li>
-                            <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.UnconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                            <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.WalletBalance.unconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
                         </ul>
                     </li>
                     @if (fiftyKOnlyFeature)
@@ -320,9 +320,9 @@
                         <li class="col-12">
                             <ul class="list-inline">
                                 <li class="list-inline-item"><strong>Federation Wallet balance :</strong></li>
-                                <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.ConfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                                <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.ConfirmedBalanceFed.ToString("N8") @Model.SidechainNode.CoinTicker</li>
                                 <li class="list-inline-item text-muted">/</li>
-                                <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.UnconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                                <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.UnconfirmedBalanceFed.ToString("N8") @Model.SidechainNode.CoinTicker</li>
                             </ul>
                         </li>
                     }

--- a/Views/Shared/Dashboard.cshtml
+++ b/Views/Shared/Dashboard.cshtml
@@ -10,409 +10,406 @@
     <partial name="Loader" />
 }
 <partial name="Modals" />
-<div id="@(ViewBag.DisplayLoader == true ? "loading-content":"")">
-    <div class="row my-2">
-        <div class="col-lg-6 col-12">
-            <div class="card mb-4">
-                <div class="card-body">
-                    <div class="pb-3 mb-3">
-                        <div class="mr-auto d-inline-block">
-                            <h3>Mainchain Node</h3>
-                        </div>
-                        <ul class="list-inline float-right d-flex align-items-center">
-                            <li class="list-inline-item">
-                                <span class="badge badge-@(Model.StratisNode.SyncingStatus >= 100 ? "success":"warning")">
-                                    <i class="material-icons">sync</i> @(Model.StratisNode.SyncingStatus >= 100 ? "Synced" : "Syncing") @Model.StratisNode.SyncingStatus.ToString("N0")%
+<div id="@(ViewBag.DisplayLoader == true ? "loading-content" : "")">
+<script type="text/javascript">
+    $(function() {
+        var settings = { searching: false, pageLength: 5, lengthMenu: false, lengthChange: false, "bDestroy": true };
+        var settings2 = { searching: false, pageLength: 10, lengthMenu: false, lengthChange: false, "bDestroy": true };
+
+        $("#stratis-peers").DataTable(settings);
+        $("#stratis-members").DataTable(settings);
+        $("#stratis-history").DataTable(settings);
+        $("#sidechain-peers").DataTable(settings);
+        $("#sidechain-members").DataTable(settings);
+        $("#sidechain-history").DataTable(settings);
+        $("#polls-table").DataTable(settings2);
+
+        setTimeout(function() {
+                $(".loader").fadeOut(function() {
+                    $("#loading-content").fadeIn();
+                });
+            },
+            500);
+    });
+</script>
+<div class="row my-2">
+<div class="col-lg-6 col-12">
+    <div class="card mb-4">
+        <div class="card-body">
+            <div class="pb-3 mb-3">
+                <div class="mr-auto d-inline-block">
+                    <h3>Mainchain Node</h3>
+                </div>
+                <ul class="list-inline float-right d-flex align-items-center">
+                    <li class="list-inline-item">
+                        <span class="badge badge-@(Model.StratisNode.SyncingStatus >= 100 ? "success" : "warning")">
+                            <i class="material-icons">sync</i> @(Model.StratisNode.SyncingStatus >= 100 ? "Synced" : "Syncing") @Model.StratisNode.SyncingStatus.ToString("N0")%
+                        </span>
+                    </li>
+                </ul>
+            </div>
+            <div class="card-text">
+                <ul class="list-inline mb-0 row">
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Swagger :</strong></li>
+                            <li class="list-inline-item"><a target="_blank" href="@Model.StratisNode.SwaggerUrl">@Model.StratisNode.SwaggerUrl</a></li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Uptime :</strong></li>
+                            <li class="list-inline-item text-muted">@Model.StratisNode.Uptime</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Block height :</strong></li>
+                            <li class="list-inline-item">@Model.StratisNode.BlockHeight</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Mempool size :</strong></li>
+                            <li class="list-inline-item text-muted">@Model.StratisNode.MempoolSize</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline d-flex align-itmes-center">
+                            <li class="list-inline-item"><strong>Block hash :</strong></li>
+                            <li class="list-inline-item text-truncate" style="max-width: 150px;">
+                                <a href="https://chainz.cryptoid.info/strat/block.dws?@(Model.StratisNode.BlockHash).htm" id="stratisBlockHash" target="_blank">@Model.StratisNode.BlockHash</a>
+                            </li>
+                            <li class="list-inline-item"><i role="copy" data-id="stratisBlockHash" data-message="Block hash successfully copied to clipboard" class="far fa-copy"></i></li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Orphan size :</strong></li>
+                            <li class="list-inline-item text-muted">@Model.StratisNode.OrphanSize</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Header height :</strong></li>
+                            <li class="list-inline-item">@Model.StratisNode.HeaderHeight</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Async Loops :</strong></li>
+                            <li class="list-inline-item text-muted">
+                                <span class="badge badge-@(Model.StratisNode.HasAsyncLoopsErrors ? "danger" : "success")">
+                                    @Model.StratisNode.AsyncLoops
                                 </span>
                             </li>
                         </ul>
-                    </div>
-                    <div class="card-text">
-                        <ul class="list-inline mb-0 row">
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Swagger :</strong></li>
-                                    <li class="list-inline-item"><a target="_blank" href="@Model.StratisNode.SwaggerUrl">@Model.StratisNode.SwaggerUrl</a></li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Uptime :</strong></li>
-                                    <li class="list-inline-item text-muted">@Model.StratisNode.Uptime</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Block height :</strong></li>
-                                    <li class="list-inline-item">@Model.StratisNode.BlockHeight</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Mempool size :</strong></li>
-                                    <li class="list-inline-item text-muted">@Model.StratisNode.MempoolSize</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline d-flex align-itmes-center">
-                                    <li class="list-inline-item"><strong>Block hash :</strong></li>
-                                    <li class="list-inline-item text-truncate" style="max-width: 150px;">
-                                        <a href="https://chainz.cryptoid.info/strat/block.dws?@(Model.StratisNode.BlockHash).htm" id="stratisBlockHash" target="_blank">@Model.StratisNode.BlockHash</a>
-                                    </li>
-                                    <li class="list-inline-item"><i role="copy" data-id="stratisBlockHash" data-message="Block hash successfully copied to clipboard" class="far fa-copy"></i></li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Orphan size :</strong></li>
-                                    <li class="list-inline-item text-muted">@Model.StratisNode.OrphanSize</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Header height :</strong></li>
-                                    <li class="list-inline-item">@Model.StratisNode.HeaderHeight</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Async Loops :</strong></li>
-                                    <li class="list-inline-item text-muted">
-                                        <span class="badge badge-@(Model.StratisNode.HasAsyncLoopsErrors ? "danger" : "success")">
-                                            @Model.StratisNode.AsyncLoops
-                                        </span>
-                                    </li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Address Indexer height :</strong></li>
-                                    <li class="list-inline-item">@Model.StratisNode.AddressIndexer</li>
-                                </ul>
-                            </li>
-                            @if (fiftyKOnlyFeature)
-                            {
-                                <li class="col-12 col-xl-12">
-                                    <ul class="list-inline">
-                                        <li class="list-inline-item"><strong>Federation Wallet balance :</strong></li>
-                                        <li class="list-inline-item text-green">Confirmed: @Model.StratisNode.ConfirmedBalance.ToString("N8") @Model.StratisNode.CoinTicker</li>
-                                        <li class="list-inline-item text-muted">/</li>
-                                        <li class="list-inline-item text-muted">Unconfirmed: @Model.StratisNode.UnconfirmedBalance.ToString("N8") @Model.StratisNode.CoinTicker</li>
-                                    </ul>
-                                </li>
-                            }
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Address Indexer height :</strong></li>
+                            <li class="list-inline-item">@Model.StratisNode.AddressIndexer</li>
                         </ul>
-                        <label class="mt-3"><strong>Peers :</strong></label>
-                        <table class="table table-sm table-striped" id="stratis-peers">
-                            <thead>
-                                <tr>
-                                    <th>Endpoint</th>
-                                    <th>Type</th>
-                                    <th>Height</th>
-                                    <th>Version</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                            @foreach (var peer in Model.StratisNode.Peers)
-                            {
-                                <tr>
-                                    <td class="text-left">@peer.Endpoint</td>
-                                    <td class="text-center">@peer.Type</td>
-                                    <td class="text-center">height:@peer.Height</td>
-                                    <td style="width: 250px;" nowrap class="text-left">agent:@peer.Version</td>
-                                </tr>
-                            }
-                            </tbody>
-                        </table>
-                        @if (fiftyKOnlyFeature)
+                    </li>
+                    @if (fiftyKOnlyFeature)
+                    {
+                        <li class="col-12 col-xl-12">
+                            <ul class="list-inline">
+                                <li class="list-inline-item"><strong>Federation Wallet balance :</strong></li>
+                                <li class="list-inline-item text-green">Confirmed: @Model.StratisNode.ConfirmedBalance.ToString("N8") @Model.StratisNode.CoinTicker</li>
+                                <li class="list-inline-item text-muted">/</li>
+                                <li class="list-inline-item text-muted">Unconfirmed: @Model.StratisNode.UnconfirmedBalance.ToString("N8") @Model.StratisNode.CoinTicker</li>
+                            </ul>
+                        </li>
+                    }
+                </ul>
+                <label class="mt-3"><strong>Peers :</strong></label>
+                <table class="table table-sm table-striped" id="stratis-peers">
+                    <thead>
+                    <tr>
+                        <th>Endpoint</th>
+                        <th>Type</th>
+                        <th>Height</th>
+                        <th>Version</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var peer in Model.StratisNode.Peers)
+                    {
+                        <tr>
+                            <td class="text-left">@peer.Endpoint</td>
+                            <td class="text-center">@peer.Type</td>
+                            <td class="text-center">height:@peer.Height</td>
+                            <td style="width: 250px;" nowrap class="text-left">agent:@peer.Version</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+                @if (fiftyKOnlyFeature)
+                {
+                    <label><strong>Multisig Federation members :</strong></label>
+                    <table class="table table-sm table-striped" id="stratis-members">
+                        <thead>
+                        <tr>
+                            <th class="text-left">Endpoint</th>
+                            <th class="text-center">Type</th>
+                            <th class="text-center">Height</th>
+                            <th style="width: 250px;" nowrap class="text-left">Version</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var member in Model.StratisNode.FederationMembers)
                         {
-                            <label><strong>Multisig Federation members :</strong></label>
-                            <table class="table table-sm table-striped" id="stratis-members">
-                                <thead>
-                                    <tr>
-                                        <th class="text-left">Endpoint</th>
-                                        <th class="text-center">Type</th>
-                                        <th class="text-center">Height</th>
-                                        <th style="width: 250px;" nowrap class="text-left">Version</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                @foreach (var member in Model.StratisNode.FederationMembers)
-                                {
-                                    <tr>
-                                        <td class="text-left reveal-on-blur">@member.Endpoint</td>
-                                        <td class="text-center">@member.Type</td>
-                                        <td class="text-center">height:@member.Height</td>
-                                        <td style="width: 250px;" nowrap class="text-left">agent:@member.Version</td>
-                                    </tr>
-                                }
-                                </tbody>
-                            </table>
+                            <tr>
+                                <td class="text-left reveal-on-blur">@member.Endpoint</td>
+                                <td class="text-center">@member.Type</td>
+                                <td class="text-center">height:@member.Height</td>
+                                <td style="width: 250px;" nowrap class="text-left">agent:@member.Version</td>
+                            </tr>
                         }
-                    </div>
-                </div>
+                        </tbody>
+                    </table>
+                }
             </div>
-            @if (fiftyKOnlyFeature)
-            {
-                <div class="card mb-4">
-                    <div class="card-body">
-                        <div class="d-flex align-items-center mb-4">
-                            <label class="d-flex justify-content-start">
-                                <strong>Federation Wallet History <small class="text-muted">(@(((JArray)Model.StratisNode?.History)?.Count ?? 0))</small></strong>
-                            </label>
-                            <span class="d-flex justify-content-end align-items-center ml-auto">
-                                <a data-toggle="modal" data-target="#stratisHistory" class="btn btn-outline-primary">See all history</a>
-                            </span>
-                        </div>
-                        <table class="table table-sm table-history" id="stratis-history">
-                            <thead>
-                                <tr>
-                                    <th class="text-center" scope="col">Status</th>
-                                    <th class="text-center" scope="col">Destination</th>
-                                    <th class="text-center" scope="col">Tx ID</th>
-                                    <th class="text-center" scope="col">Confirmed in Block</th>
-                                    <th class="text-center" scope="col">Amount</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @if (Model.StratisNode.History != null)
-                                {
-                                    foreach (dynamic transaction in ((JArray)Model.StratisNode.History).Take(5).ToList())
-                                    {
-                                        <tr>
-                                            <td class="text-center"><i class="material-icons text-green md-18">check_circle</i></td>
-                                            <td class="text-center text-truncate"><code>@(transaction.withdrawal.targetAddress)</code></td>
-                                            <td class="text-left text-truncate" style="max-width: 110px;"><a href="https://chainz.cryptoid.info/strat/tx.dws?@(transaction.withdrawal.id).htm" target="_blank">@transaction.withdrawal.id</a></td>
-                                            <td class="text-center">@transaction.withdrawal.blockNumber</td>
-                                            <td class="text-right">@(((double)transaction.withdrawal.amount / 100000000).ToString("N8")) @Model.StratisNode.CoinTicker</td>
-                                        </tr>
-                                    }
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            }
-        </div>
-        <div class="col-lg-6 col-12">
-            <div class="card mb-4">
-                <div class="card-body">
-                    <div class="pb-3 mb-3">
-                        <div class="mr-auto d-inline-block">
-                            <h3>Sidechain Node</h3>
-                        </div>
-                        <ul class="list-inline float-right d-flex align-items-center">
-                            <li class="list-inline-item">
-                                <span class="badge badge-@(Model.SidechainNode.SyncingStatus >= 100 ? "success":"warning")">
-                                    <i class="material-icons">sync</i> @(Model.SidechainNode.SyncingStatus >= 100 ? "Synced" : "Syncing") @Model.SidechainNode.SyncingStatus.ToString("N0")%
-                                </span>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="card-text">
-                        <ul class="list-inline mb-0 row">
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Swagger :</strong></li>
-                                    <li class="list-inline-item"><a target="_blank" href="@Model.SidechainNode.SwaggerUrl">@Model.SidechainNode.SwaggerUrl</a></li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Uptime :</strong></li>
-                                    <li class="list-inline-item text-muted">@Model.SidechainNode.Uptime</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Block height :</strong></li>
-                                    <li class="list-inline-item">@Model.SidechainNode.BlockHeight</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Mempool size :</strong></li>
-                                    <li class="list-inline-item text-muted">@Model.SidechainNode.MempoolSize</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline d-flex align-itmes-center">
-                                    <li class="list-inline-item"><strong>Block hash :</strong></li>
-                                    <li class="list-inline-item text-truncate" style="max-width: 150px;">
-                                        <a href="https://chainz.cryptoid.info/strat/block.dws?@(Model.SidechainNode.BlockHash).htm" id="sidechainBlockHash" target="_blank">@Model.SidechainNode.BlockHash</a>
-                                    </li>
-                                    <li class="list-inline-item"><i role="copy" data-id="sidechainBlockHash" data-message="Block hash successfully copied to clipboard" class="far fa-copy"></i></li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Orphan size :</strong></li>
-                                    <li class="list-inline-item text-muted">@Model.SidechainNode.OrphanSize</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Header height :</strong></li>
-                                    <li class="list-inline-item">@Model.SidechainNode.HeaderHeight</li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Mining Status :</strong></li>
-                                    <li class="list-inline-item text-muted">
-                                        <span class="badge badge-@(Model.SidechainNode.IsMining ? "success" : "danger")">
-                                            @(Model.SidechainNode.IsMining ? "Mining" : "Not Mining")
-                                        </span>
-                                    </li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Block Producer Hits :</strong></li>
-                                    <li class="list-inline-item">
-                                        <div class="progress" style="width: 100px;">
-                                          <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: @Model.SidechainNode.BlockProducerHitsValue%;" aria-valuenow="@Model.SidechainNode.BlockProducerHitsValue" aria-valuemin="0" aria-valuemax="100">@Model.SidechainNode.BlockProducerHitsValue%</div>
-                                        </div>
-                                    </li>
-                                </ul>
-                            </li>
-                            <li class="col-12 col-xl-6">
-                                <ul class="list-inline">
-                                    <li class="list-inline-item"><strong>Async Loops :</strong></li>
-                                    <li class="list-inline-item text-muted">
-                                        <span class="badge badge-@(Model.SidechainNode.HasAsyncLoopsErrors ? "danger" : "success")">
-                                            @Model.SidechainNode.AsyncLoops
-                                        </span>
-                                    </li>
-                                </ul>
-                            </li>
-                            @if (fiftyKOnlyFeature)
-                            {
-                                <li class="col-12">
-                                    <ul class="list-inline">
-                                        <li class="list-inline-item"><strong>Federation Wallet balance :</strong></li>
-                                        <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.ConfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
-                                        <li class="list-inline-item text-muted">/</li>
-                                        <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.UnconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
-                                    </ul>
-                                </li>
-                            }
-                        </ul>
-                        <label class="mt-3"><strong>Peers :</strong></label>
-                        <table class="table table-sm table-striped" id="sidechain-peers">
-                            <thead>
-                                <tr>
-                                    <th class="text-left">Endpoint</th>
-                                    <th class="text-center">Type</th>
-                                    <th class="text-center">Height</th>
-                                    <th style="width: 250px;" nowrap class="text-left">Version</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                            @foreach (var peer in Model.SidechainNode.Peers)
-                            {
-                                <tr>
-                                    <td class="text-left">@peer.Endpoint</td>
-                                    <td class="text-center">@peer.Type</td>
-                                    <td class="text-center">height:@peer.Height</td>
-                                    <td style="width: 250px;" nowrap class="text-left">agent:@peer.Version</td>
-                                </tr>
-                            }
-                            </tbody>
-                        </table>
-                        @if (fiftyKOnlyFeature)
-                        {
-                            <label><strong>Multisig Federation members :</strong></label>
-                            <table class="table table-sm table-striped" id="sidechain-members">
-                                <thead>
-                                    <tr>
-                                        <th class="text-left">Endpoint</th>
-                                        <th class="text-center">Type</th>
-                                        <th class="text-center">Height</th>
-                                        <th style="width: 250px;" nowrap class="text-left">Version</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                @foreach (var member in Model.SidechainNode.FederationMembers)
-                                {
-                                    <tr>
-                                        <td class="text-left reveal-on-blur">@member.Endpoint</td>
-                                        <td class="text-center">@member.Type</td>
-                                        <td class="text-center">height:@member.Height</td>
-                                        <td style="width: 250px;" nowrap class="text-left">agent:@member.Version</td>
-                                    </tr>
-                                }
-                                </tbody>
-                            </table>
-                        }
-                    </div>
-                </div>
-            </div>
-            @if (fiftyKOnlyFeature)
-            {
-                <div class="card mb-4">
-                    <div class="card-body">
-                        <div class="d-flex align-items-center mb-4">
-                            <label class="d-flex justify-content-start">
-                                <strong>Federation Wallet History <small class="text-muted">(@(((JArray)Model.StratisNode?.History)?.Count ?? 0))</small></strong>
-                            </label>
-                            <span class="d-flex justify-content-end align-items-center ml-auto">
-                                <a data-toggle="modal" data-target="#sidechainHistory" class="btn btn-outline-primary">See all history</a>
-                            </span>
-                        </div>
-                        <table class="table table-sm table-history" id="sidechain-history">
-                            <thead>
-                                <tr>
-                                    <th class="text-center" scope="col">Status</th>
-                                    <th class="text-center" scope="col">Destination</th>
-                                    <th class="text-center" scope="col">Tx ID</th>
-                                    <th class="text-center" scope="col">Confirmed in Block</th>
-                                    <th class="text-center" scope="col">Amount</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @if (Model.StratisNode.History != null)
-                                {
-                                    foreach (dynamic transaction in ((JArray)Model.SidechainNode.History).Take(5).ToList())
-                                    {
-                                        <tr>
-                                            <td class="text-center"><i class="material-icons text-green md-18">check_circle</i></td>
-                                            <td class="text-center text-truncate"><code>@(transaction.withdrawal.targetAddress)</code></td>
-                                            <td class="text-left text-truncate" style="max-width: 110px;"><a href="https://chainz.cryptoid.info/strat/tx.dws?@(transaction.withdrawal.id).htm" target="_blank">@transaction.withdrawal.id</a></td>
-                                            <td class="text-center">@transaction.withdrawal.blockNumber</td>
-                                            <td class="text-right">@(((double)transaction.withdrawal.amount / 100000000).ToString("N8")) @Model.SidechainNode.CoinTicker</td>
-                                        </tr>
-                                    }
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            }
         </div>
     </div>
+    @if (fiftyKOnlyFeature)
+    {
+        <div class="card mb-4">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-4">
+                    <label class="d-flex justify-content-start">
+                        <strong>Federation Wallet History <small class="text-muted">(@(((JArray) Model.StratisNode?.History)?.Count ?? 0))</small></strong>
+                    </label>
+                    <span class="d-flex justify-content-end align-items-center ml-auto">
+                        <a data-toggle="modal" data-target="#stratisHistory" class="btn btn-outline-primary">See all history</a>
+                    </span>
+                </div>
+                <table class="table table-sm table-history" id="stratis-history">
+                    <thead>
+                    <tr>
+                        <th class="text-center" scope="col">Status</th>
+                        <th class="text-center" scope="col">Destination</th>
+                        <th class="text-center" scope="col">Tx ID</th>
+                        <th class="text-center" scope="col">Confirmed in Block</th>
+                        <th class="text-center" scope="col">Amount</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @if (Model.StratisNode.History != null)
+                    {
+                        foreach (dynamic transaction in ((JArray) Model.StratisNode.History).Take(5).ToList())
+                        {
+                            <tr>
+                                <td class="text-center"><i class="material-icons text-green md-18">check_circle</i></td>
+                                <td class="text-center text-truncate"><code>@(transaction.withdrawal.targetAddress)</code></td>
+                                <td class="text-left text-truncate" style="max-width: 110px;"><a href="https://chainz.cryptoid.info/strat/tx.dws?@(transaction.withdrawal.id).htm" target="_blank">@transaction.withdrawal.id</a></td>
+                                <td class="text-center">@transaction.withdrawal.blockNumber</td>
+                                <td class="text-right">@(((double) transaction.withdrawal.amount / 100000000).ToString("N8")) @Model.StratisNode.CoinTicker</td>
+                            </tr>
+                        }
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
 </div>
-@section Scripts
-{
-    <script type="text/javascript">
-        $(document).ready(function() {
-            var settings = { searching: false, pageLength: 5, lengthMenu: false, lengthChange: false };
-            $("#stratis-peers").DataTable(settings);
-            $("#stratis-members").DataTable(settings);
-            $("#stratis-history").DataTable(settings);
-            $("#sidechain-peers").DataTable(settings);
-            $("#sidechain-members").DataTable(settings);
-            $("#sidechain-history").DataTable(settings);
-
-            var settings2 = { searching: false, pageLength: 10, lengthMenu: false, lengthChange: false };
-            $("#polls-table").DataTable(settings2);
-
-            setTimeout(function() {
-                    $(".loader").fadeOut(function() {
-                        $("#loading-content").fadeIn();
-                    });
-                },
-                500);
-        });
-    </script>
-}
+<div class="col-lg-6 col-12">
+    <div class="card mb-4">
+        <div class="card-body">
+            <div class="pb-3 mb-3">
+                <div class="mr-auto d-inline-block">
+                    <h3>Sidechain Node</h3>
+                </div>
+                <ul class="list-inline float-right d-flex align-items-center">
+                    <li class="list-inline-item">
+                        <span class="badge badge-@(Model.SidechainNode.SyncingStatus >= 100 ? "success" : "warning")">
+                            <i class="material-icons">sync</i> @(Model.SidechainNode.SyncingStatus >= 100 ? "Synced" : "Syncing") @Model.SidechainNode.SyncingStatus.ToString("N0")%
+                        </span>
+                    </li>
+                </ul>
+            </div>
+            <div class="card-text">
+                <ul class="list-inline mb-0 row">
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Swagger :</strong></li>
+                            <li class="list-inline-item"><a target="_blank" href="@Model.SidechainNode.SwaggerUrl">@Model.SidechainNode.SwaggerUrl</a></li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Uptime :</strong></li>
+                            <li class="list-inline-item text-muted">@Model.SidechainNode.Uptime</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Block height :</strong></li>
+                            <li class="list-inline-item">@Model.SidechainNode.BlockHeight</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Mempool size :</strong></li>
+                            <li class="list-inline-item text-muted">@Model.SidechainNode.MempoolSize</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline d-flex align-itmes-center">
+                            <li class="list-inline-item"><strong>Block hash :</strong></li>
+                            <li class="list-inline-item text-truncate" style="max-width: 150px;">
+                                <a href="https://chainz.cryptoid.info/strat/block.dws?@(Model.SidechainNode.BlockHash).htm" id="sidechainBlockHash" target="_blank">@Model.SidechainNode.BlockHash</a>
+                            </li>
+                            <li class="list-inline-item"><i role="copy" data-id="sidechainBlockHash" data-message="Block hash successfully copied to clipboard" class="far fa-copy"></i></li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Orphan size :</strong></li>
+                            <li class="list-inline-item text-muted">@Model.SidechainNode.OrphanSize</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Header height :</strong></li>
+                            <li class="list-inline-item">@Model.SidechainNode.HeaderHeight</li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Mining Status :</strong></li>
+                            <li class="list-inline-item text-muted">
+                                <span class="badge badge-@(Model.SidechainNode.IsMining ? "success" : "danger")">
+                                    @(Model.SidechainNode.IsMining ? "Mining" : "Not Mining")
+                                </span>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Block Producer Hits :</strong></li>
+                            <li class="list-inline-item">
+                                <div class="progress" style="width: 100px;">
+                                    <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: @Model.SidechainNode.BlockProducerHitsValue%;" aria-valuenow="@Model.SidechainNode.BlockProducerHitsValue" aria-valuemin="0" aria-valuemax="100">@Model.SidechainNode.BlockProducerHitsValue%</div>
+                                </div>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="col-12 col-xl-6">
+                        <ul class="list-inline">
+                            <li class="list-inline-item"><strong>Async Loops :</strong></li>
+                            <li class="list-inline-item text-muted">
+                                <span class="badge badge-@(Model.SidechainNode.HasAsyncLoopsErrors ? "danger" : "success")">
+                                    @Model.SidechainNode.AsyncLoops
+                                </span>
+                            </li>
+                        </ul>
+                    </li>
+                    @if (fiftyKOnlyFeature)
+                    {
+                        <li class="col-12">
+                            <ul class="list-inline">
+                                <li class="list-inline-item"><strong>Federation Wallet balance :</strong></li>
+                                <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.ConfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                                <li class="list-inline-item text-muted">/</li>
+                                <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.UnconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                            </ul>
+                        </li>
+                    }
+                </ul>
+                <label class="mt-3"><strong>Peers :</strong></label>
+                <table class="table table-sm table-striped" id="sidechain-peers">
+                    <thead>
+                    <tr>
+                        <th class="text-left">Endpoint</th>
+                        <th class="text-center">Type</th>
+                        <th class="text-center">Height</th>
+                        <th style="width: 250px;" nowrap class="text-left">Version</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var peer in Model.SidechainNode.Peers)
+                    {
+                        <tr>
+                            <td class="text-left">@peer.Endpoint</td>
+                            <td class="text-center">@peer.Type</td>
+                            <td class="text-center">height:@peer.Height</td>
+                            <td style="width: 250px;" nowrap class="text-left">agent:@peer.Version</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+                @if (fiftyKOnlyFeature)
+                {
+                    <label><strong>Multisig Federation members :</strong></label>
+                    <table class="table table-sm table-striped" id="sidechain-members">
+                        <thead>
+                        <tr>
+                            <th class="text-left">Endpoint</th>
+                            <th class="text-center">Type</th>
+                            <th class="text-center">Height</th>
+                            <th style="width: 250px;" nowrap class="text-left">Version</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var member in Model.SidechainNode.FederationMembers)
+                        {
+                            <tr>
+                                <td class="text-left reveal-on-blur">@member.Endpoint</td>
+                                <td class="text-center">@member.Type</td>
+                                <td class="text-center">height:@member.Height</td>
+                                <td style="width: 250px;" nowrap class="text-left">agent:@member.Version</td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                }
+            </div>
+        </div>
+    </div>
+    @if (fiftyKOnlyFeature)
+    {
+        <div class="card mb-4">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-4">
+                    <label class="d-flex justify-content-start">
+                        <strong>Federation Wallet History <small class="text-muted">(@(((JArray) Model.StratisNode?.History)?.Count ?? 0))</small></strong>
+                    </label>
+                    <span class="d-flex justify-content-end align-items-center ml-auto">
+                        <a data-toggle="modal" data-target="#sidechainHistory" class="btn btn-outline-primary">See all history</a>
+                    </span>
+                </div>
+                <table class="table table-sm table-history" id="sidechain-history">
+                    <thead>
+                    <tr>
+                        <th class="text-center" scope="col">Status</th>
+                        <th class="text-center" scope="col">Destination</th>
+                        <th class="text-center" scope="col">Tx ID</th>
+                        <th class="text-center" scope="col">Confirmed in Block</th>
+                        <th class="text-center" scope="col">Amount</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @if (Model.StratisNode.History != null)
+                    {
+                        foreach (dynamic transaction in ((JArray) Model.SidechainNode.History).Take(5).ToList())
+                        {
+                            <tr>
+                                <td class="text-center"><i class="material-icons text-green md-18">check_circle</i></td>
+                                <td class="text-center text-truncate"><code>@(transaction.withdrawal.targetAddress)</code></td>
+                                <td class="text-left text-truncate" style="max-width: 110px;"><a href="https://chainz.cryptoid.info/strat/tx.dws?@(transaction.withdrawal.id).htm" target="_blank">@transaction.withdrawal.id</a></td>
+                                <td class="text-center">@transaction.withdrawal.blockNumber</td>
+                                <td class="text-right">@(((double) transaction.withdrawal.amount / 100000000).ToString("N8")) @Model.SidechainNode.CoinTicker</td>
+                            </tr>
+                        }
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>
+</div>
+</div>

--- a/Views/Shared/Dashboard.cshtml
+++ b/Views/Shared/Dashboard.cshtml
@@ -310,9 +310,9 @@
                     <li class="col-12">
                         <ul class="list-inline">
                             <li class="list-inline-item"><strong>Mining Wallet balance :</strong></li>
-                            <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.WalletBalance.confirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                            <li class="list-inline-item text-green">Confirmed: @Model.SidechainNode.ConfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
                             <li class="list-inline-item text-muted">/</li>
-                            <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.WalletBalance.unconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
+                            <li class="list-inline-item text-muted">Unconfirmed: @Model.SidechainNode.UnconfirmedBalance.ToString("N8") @Model.SidechainNode.CoinTicker</li>
                         </ul>
                     </li>
                     @if (fiftyKOnlyFeature)

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -112,9 +112,9 @@
     <script type="text/javascript" src="~/lib/jquery-ajax-unobtrusive/dist/jquery.unobtrusive-ajax.min.js"></script>
     <script type="text/javascript" src="~/lib/node-snackbar/dist/snackbar.min.js"></script>
     <script type="text/javascript" src="~/lib/nprogress/nprogress.js"></script>
-    <script type="text/javascript" src="~/js/default.js"></script>
     <script type="text/javascript" src="~/lib/datatables/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript" src="~/lib/datatables/js/dataTables.bootstrap4.min.js"></script>
+    <script type="text/javascript" src="~/js/default.js"></script>
 </environment>
 <environment exclude="Development">
     <script type="text/javascript" src="~/js/default.bundle.min.js"></script>

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -11,6 +11,6 @@
     "SidechainNode": "http://localhost:38223",
     "SidechainNodeType": "10K",
     "EnvType": "TestNet",
-    "IntervalTime": "3"
+    "IntervalTime": "30"
   }
 }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -10,6 +10,7 @@
     "StratisNode": "http://localhost:38221",
     "SidechainNode": "http://localhost:38223",
     "SidechainNodeType": "10K",
-    "EnvType": "TestNet"
+    "EnvType": "TestNet",
+    "IntervalTime": "3"
   }
 }

--- a/appsettings.Docker10K.json
+++ b/appsettings.Docker10K.json
@@ -10,6 +10,7 @@
     "StratisNode": "http://nodemaa:37221",
     "SidechainNode": "http://nodesbe:37221",
     "SidechainNodeType": "10K",
-    "EnvType": "MainNet"
+    "EnvType": "MainNet",
+    "IntervalTime": "3"
   }
 }

--- a/appsettings.Docker50K.json
+++ b/appsettings.Docker50K.json
@@ -10,6 +10,7 @@
     "StratisNode": "http://nodemaa:37221",
     "SidechainNode": "http://nodesaa:37221",
     "SidechainNodeType": "50K",
-    "EnvType": "MainNet"
+    "EnvType": "MainNet",
+    "IntervalTime": "3"
   }
 }

--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -11,6 +11,6 @@
     "SidechainNode": "http://localhost:37223",
     "SidechainNodeType": "50K",
     "EnvType": "MainNet",
-    "IntervalTime":  "30"
+    "IntervalTime": "30"
   }
 }

--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -10,6 +10,7 @@
     "StratisNode": "http://localhost:37221",
     "SidechainNode": "http://localhost:37223",
     "SidechainNodeType": "50K",
-    "EnvType": "MainNet"
+    "EnvType": "MainNet",
+    "IntervalTime":  "30"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,7 +8,8 @@
     "StratisNode": "http://localhost:37221",
     "SidechainNode": "http://localhost:37223",
     "SidechainNodeType": "10K",
-    "EnvType": "MainNet"
+    "EnvType": "MainNet",
+    "IntervalTime": "30"
   },
   "AllowedHosts": "*"
 }

--- a/wwwroot/js/default.js
+++ b/wwwroot/js/default.js
@@ -30,11 +30,8 @@ $(document).ready(function()
     signalrHub.on("CacheIsDifferent", function () {
         NProgress.start();
         CacheIsDifferent = true;
-        if($('.modal').hasClass('show') == false)
-        {
-            $("#container").load("/update-dashboard");
-            Snackbar.close();
-        }
+        $("#container").load("/update-dashboard");
+        Snackbar.close();
         NProgress.done();
     });
     signalrHub.on("NodeUnavailable", function () {

--- a/wwwroot/js/default.js
+++ b/wwwroot/js/default.js
@@ -28,7 +28,7 @@ $(document).ready(function()
     NProgress.start();
     var signalrHub = new signalR.HubConnectionBuilder().withUrl("/ws-updater").build();
     signalrHub.on("CacheIsDifferent", function () {
-        NProgress.start();
+		NProgress.start();
         CacheIsDifferent = true;
         $("#container").load("/update-dashboard");
         Snackbar.close();
@@ -39,15 +39,6 @@ $(document).ready(function()
         Snackbar.show({text: "The full nodes API are unavailable", pos: "bottom-center", duration: 0, actionText: 'REFRESH', onActionClick: function() {document.location.reload();}});
     });
     signalrHub.start();
-
-    // Detects modal closing for refresh the dashboard
-    $('.modal').on('hidden.bs.modal', function () {
-        if(CacheIsDifferent)
-        {
-            // $("#container").load("/update-dashboard");
-            // Snackbar.close();
-        }
-    });
 
     // Prevent modal disclosure
     $(".close").click(function()


### PR DESCRIPTION
1. Remove modal check from default.js on signalR call when cash is changed
2. Move jQuery dataTable formatting within div on dashboard partial to maintain pagination on refresh
3. Fix precision for node uptime
4. Make refresh interval configurable
5. Default dev appsettings to refresh interval of 30 seconds
6. Refactor wallet properties 
7. Display mining balance for Cirrus Node view
8. Fix for parsing wallet balances