### PR TITLE
Update LibraryManager

### DIFF
--- a/src/StratisMasternodeDashboard/Stratis.FederatedSidechains.AdminDashboard.csproj
+++ b/src/StratisMasternodeDashboard/Stratis.FederatedSidechains.AdminDashboard.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="BundlerMinifier.Core" Version="2.9.406" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageReference Include="NBitcoin" Version="4.1.2.36" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="QRCoder" Version="1.3.5" />


### PR DESCRIPTION
Updating the LibraryManager fixes the error 'Library could not be resolved by the "cdnjs" provider' for the libman libraries.